### PR TITLE
Update Lead.php. Add "loss_reason_id" and "loss_reason_name" to writable attributes

### DIFF
--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -22,9 +22,7 @@ class Lead extends \Ufee\Amo\Base\Models\ModelWithCF
 			'updatedUser',
 			'tags',
 			'pipeline',
-			'status',
-			'loss_reason_id',
-			'loss_reason_name',
+			'status',			
 			'customFields',
 			'contacts',
 			'contact',
@@ -47,7 +45,9 @@ class Lead extends \Ufee\Amo\Base\Models\ModelWithCF
 			'updated_by',
 			'closed_at',
 			'closest_task_at',
-			'visitor_uid'
+			'visitor_uid',
+			'loss_reason_id',
+			'loss_reason_name'
 		];
 
     /**


### PR DESCRIPTION
Когда закрываешь сделку в статус 143(не успешно) было бы отлично, если бы можно было передать и причину закрытия(через имя или id)