### PR TITLE
Update Collection.php

### DIFF
--- a/src/Base/Collections/Collection.php
+++ b/src/Base/Collections/Collection.php
@@ -22,7 +22,7 @@ class Collection implements \IteratorAggregate
      * Collection iterator
 	 * @return \ArrayIterator
      */
-	public function getIterator()
+	public function getIterator(): \Traversable
 	{
 		return new \ArrayIterator($this->items);
 	}


### PR DESCRIPTION
As of PHP 8.1, fixed return type of the functions getIterator() to match with interface public: Traversable